### PR TITLE
gx: update go-libp2p-peerstore

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.2.14: QmcCgouQ5iXfmxmVNc1fpXLacRSPMNHx4tzqDpou6XNvvd
+0.2.15: Qma2j8dYePrvN5DoNgwh1uAuu3FFtEtrUQFmr737ws8nCp

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "QmVHSBsn8LEeay8m5ERebgUVuhzw838PsyTttCmP6GMJkg",
+      "hash": "QmRscs8KxrSmSv4iuevHv8JfuUzHBMoqiaHzxfDRiksd6e",
       "name": "go-libp2p-net",
-      "version": "1.6.9"
+      "version": "1.6.11"
     },
     {
       "author": "whyrusleeping",
@@ -21,9 +21,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "Qmeo7oJxR65PLPx68KPFi8rjzcEmmWN2dL66fPuq9nVMv8",
+      "hash": "QmVkDnNm71vYyY6s6rXwtmyDYis3WkKyrEhMECwT6R12uJ",
       "name": "go-libp2p-swarm",
-      "version": "1.6.14"
+      "version": "1.6.15"
     }
   ],
   "gxVersion": "0.10.0",
@@ -31,6 +31,6 @@
   "license": "",
   "name": "go-libp2p-netutil",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.2.14"
+  "version": "0.2.15"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-net/pull/7
- https://github.com/libp2p/go-libp2p-metrics/pull/2
- https://github.com/libp2p/go-libp2p-host/pull/3
- https://github.com/libp2p/go-libp2p-swarm/pull/22