### PR TITLE
gx: update go-addr-util, go-libp2p-swarm

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.2.15: Qma2j8dYePrvN5DoNgwh1uAuu3FFtEtrUQFmr737ws8nCp
+0.2.16: QmbED8x6RYDbHRsGfBjPxG3Lw15GjKCPLgoyokhpk9xNgW

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmVkDnNm71vYyY6s6rXwtmyDYis3WkKyrEhMECwT6R12uJ",
+      "hash": "QmbLpTGb9Y6Yh3KondeFx1RibwUmKomwNVX38HigZfbiZz",
       "name": "go-libp2p-swarm",
-      "version": "1.6.15"
+      "version": "1.6.17"
     }
   ],
   "gxVersion": "0.10.0",
@@ -31,6 +31,6 @@
   "license": "",
   "name": "go-libp2p-netutil",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.2.15"
+  "version": "0.2.16"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-conn/pull/10
- https://github.com/libp2p/go-libp2p-swarm/pull/24


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace