### PR TITLE
gx: update go-testutil

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.2.19: QmSTbByZ1rJVn8KANcoiLDiPH2pgDaz33uT6JW6B9nMBW5
+0.2.20: QmPVjuusqQxSZrE3e35qvnge8n7Hs7NnfkHyFdkaBkWQdB

--- a/package.json
+++ b/package.json
@@ -15,15 +15,15 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmSXpwmggGd8fe7e9abqRuST7SqaZjrz3Cg5avMJbdmKGe",
+      "hash": "QmYazuWNCrC7LXeRt3utQuRsCDufpNM176rD1efuvF2pWJ",
       "name": "go-testutil",
-      "version": "1.1.8"
+      "version": "1.1.9"
     },
     {
       "author": "whyrusleeping",
-      "hash": "Qmb9GA1fMGfXdLBwJA9h3SRpr7C4AXUhpWgZzVmqcDJi1P",
+      "hash": "QmW8QNRUf1nqeRxZdhGg5DVcxHMwxuuNt7AWfmDi2a8JE2",
       "name": "go-libp2p-swarm",
-      "version": "1.7.1"
+      "version": "1.7.2"
     },
     {
       "author": "whyrusleeping",
@@ -60,6 +60,6 @@
   "license": "",
   "name": "go-libp2p-netutil",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.2.19"
+  "version": "0.2.20"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-conn/pull/11
- https://github.com/libp2p/go-libp2p-connmgr/pull/2
- https://github.com/libp2p/go-libp2p-host/pull/5
- https://github.com/libp2p/go-libp2p-swarm/pull/27


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace