### PR TITLE
gx: update go-testutil

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.2.20: QmPVjuusqQxSZrE3e35qvnge8n7Hs7NnfkHyFdkaBkWQdB
+0.2.21: QmZG4W8GR9FpC4z69Vab9ENtEoxKjDnTym5oa7Q3Yr7P4o

--- a/package.json
+++ b/package.json
@@ -15,15 +15,15 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmYazuWNCrC7LXeRt3utQuRsCDufpNM176rD1efuvF2pWJ",
+      "hash": "QmZJD56ZWLViJAVkvLc7xbbDerHzUMLr2X4fLRYfbxZWDN",
       "name": "go-testutil",
-      "version": "1.1.9"
+      "version": "1.1.10"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmW8QNRUf1nqeRxZdhGg5DVcxHMwxuuNt7AWfmDi2a8JE2",
+      "hash": "QmfGXKgqQmaPHDHPSG3Y9vCVtFZtFeRZJW7N1anXB5biRu",
       "name": "go-libp2p-swarm",
-      "version": "1.7.2"
+      "version": "1.7.3"
     },
     {
       "author": "whyrusleeping",
@@ -60,6 +60,6 @@
   "license": "",
   "name": "go-libp2p-netutil",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.2.20"
+  "version": "0.2.21"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-conn/pull/12
- https://github.com/libp2p/go-libp2p-connmgr/pull/3
- https://github.com/libp2p/go-libp2p-host/pull/6
- https://github.com/libp2p/go-libp2p-swarm/pull/28


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace