### PR TITLE
gx: update go-cid, go-multibase, base32

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.2.22: QmYdcTdkuCvFXLj2uejJF5aY3HWhtd8JLT4BjPxF9BNPYf
+0.2.23: QmYTeBaLWbFKQAtVTHbxvTbKfgqrGJUupK4UwjeugownfD

--- a/package.json
+++ b/package.json
@@ -15,15 +15,15 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmZJD56ZWLViJAVkvLc7xbbDerHzUMLr2X4fLRYfbxZWDN",
+      "hash": "QmWRCn8vruNAzHx8i6SAXinuheRitKEGu8c7m26stKvsYx",
       "name": "go-testutil",
-      "version": "1.1.10"
+      "version": "1.1.11"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmVJefKHXEx28RFpmj5GeRg43AqeBH3npPwvgJ875fBPm7",
+      "hash": "QmQ8c9nscf6kxoxCoXGxuXWB4ruQ1ttfRG5gKcQbNgJvGr",
       "name": "go-libp2p-swarm",
-      "version": "1.7.4"
+      "version": "1.7.5"
     },
     {
       "author": "whyrusleeping",
@@ -60,6 +60,6 @@
   "license": "",
   "name": "go-libp2p-netutil",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.2.22"
+  "version": "0.2.23"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-testutil/pull/12
- https://github.com/libp2p/go-libp2p-conn/pull/15
- https://github.com/libp2p/go-libp2p-connmgr/pull/5
- https://github.com/libp2p/go-libp2p-host/pull/8
- https://github.com/libp2p/go-libp2p-swarm/pull/32


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace