### PR TITLE
gx: update go-ws-transport

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.2.24: QmPqZ86tyhGdYoLdJNFLUPqQkiqtghY13xmKnCMG9wcyrB
+0.2.25: QmQ1bJEsmdEiGfTQRoj6CsshWmAKduAEDEbwzbvk5QT5Ui

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmYJkfefr2gXX6jf8z18oD8GY3wrqCH99XKg8e2K1cEBVX",
+      "hash": "QmQUmDr1DMDDy6KMSsJuyV9nVD7dJZ9iWxXESQWPvte2NP",
       "name": "go-libp2p-swarm",
-      "version": "1.7.6"
+      "version": "1.7.7"
     },
     {
       "author": "whyrusleeping",
@@ -60,6 +60,6 @@
   "license": "",
   "name": "go-libp2p-netutil",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.2.24"
+  "version": "0.2.25"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-floodsub/pull/36
- https://github.com/libp2p/go-libp2p-kad-dht/pull/87
- https://github.com/libp2p/go-addr-util/pull/6
- https://github.com/libp2p/go-libp2p-conn/pull/16
- https://github.com/libp2p/go-libp2p-swarm/pull/34


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace