### PR TITLE
gx: update go-peerstream

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.3.2: QmdzuGp4a9pahgXuBeReHdYGUzdVX3FUCwfmWVo5mQfkTi
+0.3.3: QmQGX417WoxKxDJeHqouMEmmH4G1RCENNSzkZYHrXy3Xb3

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmWpJ4y2vxJ6GZpPfQbpVpQxAYS3UeR6AKNbAHxw7wN3qw",
+      "hash": "QmdQFrFnPrKRQtpeHKjZ3cVNwxmGKKS2TvhJTuN9C9yduh",
       "name": "go-libp2p-swarm",
-      "version": "2.0.3"
+      "version": "2.0.5"
     },
     {
       "author": "whyrusleeping",
@@ -60,6 +60,6 @@
   "license": "",
   "name": "go-libp2p-netutil",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.3.2"
+  "version": "0.3.3"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-swarm/pull/39


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace