### PR TITLE
Add Raw() and Type() methods

### DIFF
--- a/key.go
+++ b/key.go
@@ -8,6 +8,7 @@ import (
 
 	logging "github.com/ipfs/go-log"
 	ic "github.com/libp2p/go-libp2p-crypto"
+	pb "github.com/libp2p/go-libp2p-crypto/pb"
 	peer "github.com/libp2p/go-libp2p-peer"
 	testutil "github.com/libp2p/go-testutil"
 
@@ -41,6 +42,17 @@ func (pk TestBogusPublicKey) Equals(k ic.Key) bool {
 	return ic.KeyEqual(pk, k)
 }
 
+// Raw returns the raw bytes of the key (not wrapped in the
+// libp2p-crypto protobuf).
+func (pk TestBogusPublicKey) Raw() ([]byte, error) {
+	return pk, nil
+}
+
+// Type returns the protobof key type.
+func (pk TestBogusPublicKey) Type() pb.KeyType {
+	return pb.KeyType_RSA
+}
+
 func (sk TestBogusPrivateKey) GenSecret() []byte {
 	return []byte(sk)
 }
@@ -66,6 +78,17 @@ func (sk TestBogusPrivateKey) Bytes() ([]byte, error) {
 // Equals checks whether this key is equal to another
 func (sk TestBogusPrivateKey) Equals(k ic.Key) bool {
 	return ic.KeyEqual(sk, k)
+}
+
+// Raw returns the raw bytes of the key (not wrapped in the
+// libp2p-crypto protobuf).
+func (sk TestBogusPrivateKey) Raw() ([]byte, error) {
+	return sk, nil
+}
+
+// Type returns the protobof key type.
+func (pk TestBogusPrivateKey) Type() pb.KeyType {
+	return pb.KeyType_RSA
 }
 
 func RandTestBogusPrivateKey() (TestBogusPrivateKey, error) {


### PR DESCRIPTION
Add Raw() and Type() methods that are required in order to implement the [go-libp2p-crypto](https://github.com/libp2p/go-libp2p-crypto/commit/9c870c1a53c3d573b715a7049bd7c6e250ed8c0d) interface

Closes https://github.com/libp2p/go-libp2p-netutil/issues/22